### PR TITLE
Bumped to version 2.8.2

### DIFF
--- a/sp2013.searchquerytool/SearchQueryTool.nuspec
+++ b/sp2013.searchquerytool/SearchQueryTool.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <version>2.7.0.0</version>
+    <version>2.8.2.0</version>
     <authors>nadeemis</authors>
     <owners>Max Melcher</owners>
     <licenseUrl>https://github.com/SharePoint/PnP-Tools/blob/master/LICENSE</licenseUrl>
@@ -20,5 +20,6 @@ Can be used to query both SharePoint 2013 On-Premise, and SharePoint Online.</de
   </metadata>
   <files>
     <file src="tools\ChocolateyInstall.ps1" target="tools\ChocolateyInstall.ps1" />
+    <file src="tools\ChocolateyUninstall.ps1" target="tools\ChocolateyUninstall.ps1" />
   </files>
 </package>

--- a/sp2013.searchquerytool/tools/ChocolateyInstall.ps1
+++ b/sp2013.searchquerytool/tools/ChocolateyInstall.ps1
@@ -1,5 +1,22 @@
-$scriptPath = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-Install-ChocolateyZipPackage "sp2013.searchquerytool" "https://github.com/SharePoint/PnP-Tools/blob/master/Solutions/SharePoint.Search.QueryTool/Releases/SearchQueryToolv2.7.zip?raw=true" "$scriptPath"
-$exePath = Join-Path $scriptPath 'SearchQueryTool.exe'
-  
-Install-ChocolateyDesktopLink $exePath 
+$ErrorActionPreference = 'Stop';
+
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$packageArgs = @{
+  packageName   = "SearchQueryTool"
+  unzipLocation = $toolsDir
+  url           = "https://github.com/SharePoint/PnP-Tools/blob/master/Solutions/SharePoint.Search.QueryTool/Releases/SearchQueryToolv2.8.2.zip?raw=true"
+
+  checksum      = "527797173FB53A66016E29553756188096B4556BF6CD455020E58A104BC90997"
+  checksumType  = "sha256"
+}
+
+Install-ChocolateyZipPackage @packageArgs 
+
+Write-Verbose "Adding Desktop-Link"
+$target = Join-Path -Path $toolsDir -ChildPath "SearchQueryTool.exe"
+$desktop = $([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::DesktopDirectory))
+$shortcut = Join-Path -Path $desktop -ChildPath "SearchQueryTool.lnk"
+Install-ChocolateyShortcut `
+   -ShortcutFilePath $shortcut `
+   -TargetPath $target

--- a/sp2013.searchquerytool/tools/ChocolateyUninstall.ps1
+++ b/sp2013.searchquerytool/tools/ChocolateyUninstall.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = 'Stop';
+
+Write-Verbose "Removing Desktop-Link"
+$desktop = $([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::DesktopDirectory))
+$shortcut = Join-Path -Path $desktop -ChildPath ("SearchQueryTool.lnk")
+if(Test-Path $shortcut) {
+  Remove-Item $shortcut
+}


### PR DESCRIPTION
- bumped the version to 2.8.2.
- updated ChocolateyInstall.ps1 to utilize the current syntax/helpers
- created ChocokateyUninstall.ps1 to remove the desktop-shortcut