### PR TITLE
Version of SearchQueryTool to 2.8.4

### DIFF
--- a/sp2013.searchquerytool/SearchQueryTool.nuspec
+++ b/sp2013.searchquerytool/SearchQueryTool.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SearchQueryTool</id>
-    <version>2.8.2.0</version>
+    <version>2.8.4.0</version>
     <title>SearchQueryTool</title>
     <authors>nadeemis</authors>
     <owners>Max Melcher</owners>
@@ -13,7 +13,7 @@
 
 After running the query, you can view all types of result sets returned; Primary Results, Refinement Results, Query Rules Results, Query Suggestions, in addition to the actual raw response received from the Search service.
 
-Can be used to query both SharePoint 2013 On-Premise, and SharePoint Online.</description>
+Can be used to query SharePoint 2013, 2016, 2019 On-Premises, and SharePoint Online.</description>
     <summary>Use this tool to test out and debug search queries against the SharePoint 2013 Search REST API.</summary>
     <language>en-US</language>
     <tags>SharePoint SP2013 chocolatey Search REST Query</tags>

--- a/sp2013.searchquerytool/tools/ChocolateyInstall.ps1
+++ b/sp2013.searchquerytool/tools/ChocolateyInstall.ps1
@@ -5,9 +5,9 @@ $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $packageArgs = @{
   packageName   = "SearchQueryTool"
   unzipLocation = $toolsDir
-  url           = "https://github.com/SharePoint/PnP-Tools/blob/master/Solutions/SharePoint.Search.QueryTool/Releases/SearchQueryToolv2.8.2.zip?raw=true"
+  url           = "https://github.com/SharePoint/PnP-Tools/releases/download/v2.8.4-Search-QueryTool/SearchQueryToolv2.8.4.zip"
 
-  checksum      = "527797173FB53A66016E29553756188096B4556BF6CD455020E58A104BC90997"
+  checksum      = "1E9F2288CEDAB95533C8694F90CE29C3D782A250BCECBFA8EC4C98D5DED05835"
   checksumType  = "sha256"
 }
 


### PR DESCRIPTION
The 2.8.2-Version is no longer able to download. The download-link was changed. Also, I bumped to the most recent version.